### PR TITLE
Formatting of StdOut, StdErr and StackTrace

### DIFF
--- a/TrxerConsole/Trxer.css
+++ b/TrxerConsole/Trxer.css
@@ -359,3 +359,12 @@ td.slowest {
 .visibleRow {
     visibility: visible;
 }
+
+.wordwrap {
+    white-space: pre-wrap; /* css-3 */
+    white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+    white-space: -pre-wrap; /* Opera 4-6 */
+    white-space: -o-pre-wrap; /* Opera 7 */
+    word-wrap: break-word; /* Internet Explorer 5.5+ */ 
+    word-break: break-all; /* Firefox */
+}

--- a/TrxerConsole/Trxer.css
+++ b/TrxerConsole/Trxer.css
@@ -218,7 +218,7 @@ td.slowest {
 }
 
 .SummaryDiv {
-    width: 90%;
+    width: 98%;
     border-top: 1px solid #e5eff8;
     border-right: 1px solid #e5eff8;
     margin: 1em auto;

--- a/TrxerConsole/Trxer.xslt
+++ b/TrxerConsole/Trxer.xslt
@@ -481,7 +481,45 @@
           <xsl:value-of select="trxreport:ToExactTimeDefinition(@duration)" />
         </td>
       </tr>
-      <tr id="{generate-id($testId)}Stacktrace" class="hiddenRow">
+      <tr id="{generate-id($testId)}StdOut" class="hiddenRow">
+        <!--Outer-->
+        <td colspan="6">
+          <div id="exceptionArrow">↳</div>
+          <table>
+            <!--Inner-->
+            <tbody>
+              <tr class="visibleRow">
+                <td class="ex">
+                  <xsl:value-of select="text" />
+                  <xsl:call-template name="break">
+                    <xsl:with-param name="text" select="/t:TestRun/t:Results/t:UnitTestResult[@testId=$testId]/t:Output/t:StdOut" />
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr id="{generate-id($testId)}StdErr" class="hiddenRow">
+        <!--Outer-->
+        <td colspan="6">
+          <div id="exceptionArrow">↳</div>
+          <table>
+            <!--Inner-->
+            <tbody>
+              <tr class="visibleRow">
+                <td class="ex">
+                  <xsl:value-of select="text" />
+                  <xsl:call-template name="break">
+                    <xsl:with-param name="text" select="/t:TestRun/t:Results/t:UnitTestResult[@testId=$testId]/t:Output/t:StdErr" />
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr id="{generate-id($testId)}StackTrace" class="hiddenRow">
         <!--Outer-->
         <td colspan="6">
           <div id="exceptionArrow">↳</div>
@@ -525,51 +563,35 @@
           <div class="atachmentImage" onclick="show('floatingImageBackground');updateFloatingImage('{$MessageErrorInfo}');"></div>
         </xsl:when>
       </xsl:choose>
-
     </xsl:for-each>
   </xsl:template>
-
-
-
-
-
-
 
   <xsl:template name="debugInfo">
     <xsl:param name="testId" />
     <xsl:for-each select="/t:TestRun/t:Results/t:UnitTestResult[@testId=$testId]/t:Output">
-
-      <xsl:variable name="MessageErrorStacktrace" select="t:ErrorInfo/t:StackTrace"/>
-
-      <xsl:variable name="StdOut" select="text" />
+      <xsl:variable name="Message" select="text" />
       <xsl:call-template name="break">
-        <xsl:with-param name="text" select="t:StdOut" />
+        <xsl:with-param name="text" select="t:ErrorInfo/t:Message" />
       </xsl:call-template>
-      <xsl:if test="$StdOut or $MessageErrorStacktrace">
-        <xsl:value-of select="$StdOut"/>
-        <xsl:if test="$MessageErrorStacktrace">
-          <a style="float:right;" id="{generate-id($testId)}StacktraceToggle" href="javascript:ShowHide('{generate-id($testId)}Stacktrace','{generate-id($testId)}StacktraceToggle','Show Stacktrace','Hide Stacktrace');">Show Stacktrace</a>
-        </xsl:if>
-        <xsl:if test="$StdOut">
-          <br/>
-        </xsl:if>
+
+      <xsl:variable name="StdOut" select="t:StdOut" />
+      <xsl:variable name="StdErr" select="t:StdErr" />
+      <xsl:variable name="StackTrace" select="t:ErrorInfo/t:StackTrace"/>
+      <xsl:if test="$StdOut">
+        <div class="OpenMoreButton" style="float:right;" onclick="ShowHide('{generate-id($testId)}StdOut','{generate-id($testId)}StdOutButton','Show StdOut','Hide StdOut');">
+          <div class="MoreButtonText" id="{generate-id($testId)}StdOutButton">Show StdOut</div>
+        </div>
       </xsl:if>
-      <xsl:variable name="StdErr" select="text" />
-      <xsl:call-template name="break">
-        <xsl:with-param name="text" select="t:StdErr" />
-      </xsl:call-template>
       <xsl:if test="$StdErr">
-        <xsl:value-of select="$StdErr"/>
-        <br/>
+        <div class="OpenMoreButton" style="float:right;" onclick="ShowHide('{generate-id($testId)}StdErr','{generate-id($testId)}StdErrButton','Show StdErr','Hide StdErr');">
+          <div class="MoreButtonText" id="{generate-id($testId)}StdErrButton">Show StdErr</div>
+        </div>
       </xsl:if>
-      <xsl:variable name="MessageErrorInfo" select="t:ErrorInfo/t:Message"/>
-      <xsl:if test="$MessageErrorInfo">
-        <xsl:value-of select="$MessageErrorInfo"/>
-        <br/>
+      <xsl:if test="$StackTrace">
+        <div class="OpenMoreButton" style="float:right;" onclick="ShowHide('{generate-id($testId)}StackTrace','{generate-id($testId)}StackTraceButton','Show StackTrace','Hide StackTrace');">
+          <div class="MoreButtonText" id="{generate-id($testId)}StackTraceButton">Show StackTrace</div>
+        </div>
       </xsl:if>
-
-
-
     </xsl:for-each>
   </xsl:template>
 

--- a/TrxerConsole/Trxer.xslt
+++ b/TrxerConsole/Trxer.xslt
@@ -490,7 +490,10 @@
             <tbody>
               <tr class="visibleRow">
                 <td class="ex">
-                  <xsl:value-of select="/t:TestRun/t:Results/t:UnitTestResult[@testId=$testId]/t:Output/t:ErrorInfo/t:StackTrace" />
+                  <xsl:value-of select="text" />
+                  <xsl:call-template name="break">
+                    <xsl:with-param name="text" select="/t:TestRun/t:Results/t:UnitTestResult[@testId=$testId]/t:Output/t:ErrorInfo/t:StackTrace" />
+                  </xsl:call-template>
                 </td>
               </tr>
             </tbody>
@@ -538,7 +541,10 @@
 
       <xsl:variable name="MessageErrorStacktrace" select="t:ErrorInfo/t:StackTrace"/>
 
-      <xsl:variable name="StdOut" select="t:StdOut"/>
+      <xsl:variable name="StdOut" select="text" />
+      <xsl:call-template name="break">
+        <xsl:with-param name="text" select="t:StdOut" />
+      </xsl:call-template>
       <xsl:if test="$StdOut or $MessageErrorStacktrace">
         <xsl:value-of select="$StdOut"/>
         <xsl:if test="$MessageErrorStacktrace">
@@ -548,8 +554,10 @@
           <br/>
         </xsl:if>
       </xsl:if>
-      <xsl:value-of select="t:StdErr" />
-      <xsl:variable name="StdErr" select="t:StdErr"/>
+      <xsl:variable name="StdErr" select="text" />
+      <xsl:call-template name="break">
+        <xsl:with-param name="text" select="t:StdErr" />
+      </xsl:call-template>
       <xsl:if test="$StdErr">
         <xsl:value-of select="$StdErr"/>
         <br/>
@@ -563,6 +571,23 @@
 
 
     </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="break">
+    <xsl:param name="text" />
+    <xsl:param name="replace" select="'&#10;'" />
+    <xsl:choose>
+      <xsl:when test="contains($text,$replace)">
+        <xsl:value-of select="substring-before($text,$replace)"/>
+        <br />
+        <xsl:call-template name="break">
+          <xsl:with-param name="text" select="substring-after($text,$replace)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$text" />
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 </xsl:stylesheet>
 

--- a/TrxerConsole/TrxerTable.css
+++ b/TrxerConsole/TrxerTable.css
@@ -10,7 +10,7 @@ img {
 }
 
 table {
-    width: 90%;
+    width: 98%;
     margin: 1em auto;
     border-collapse: collapse;
     border: 1px solid #a2caf2;


### PR DESCRIPTION
In order to keep the test tables compact
I want the StdOut, StdErr and StackTrace output to be placed in a separate row and expandable/collapsible with a toggle button
and I want the message to be limited to three lines, the full message placed in a separate row and expandable/collapsible with a toggle button.
