### PR TITLE
Add handling of empty datetimes

### DIFF
--- a/TrxerConsole/Trxer.xslt
+++ b/TrxerConsole/Trxer.xslt
@@ -21,6 +21,11 @@
     }
     public string GetShortDateTime(string time)
     {
+      if( string.IsNullOrEmpty(time) )
+      {
+        return string.Empty;
+      }
+      
       return DateTime.Parse(time).ToString();
     }
     
@@ -40,7 +45,12 @@
     
     public string ToExactTimeDefinition(string duration)
     {
-         return  ToExtactTime(TimeSpan.Parse(duration).TotalMilliseconds);
+      if( string.IsNullOrEmpty(duration) )
+      {
+        return string.Empty;
+      } 
+    
+      return  ToExtactTime(TimeSpan.Parse(duration).TotalMilliseconds);
     }
     
     public string ToExactTimeDefinition(string start,string finish)


### PR DESCRIPTION
When a test run is interrupted, some datetime fields in the .trx are left empty. To account for this, we need to skip those when transforming.
