### PR TITLE
Fixed ArgumentOutOfRangeException in some assemblies

### DIFF
--- a/TrxerConsole/Trxer.xslt
+++ b/TrxerConsole/Trxer.xslt
@@ -12,7 +12,10 @@
     <![CDATA[
     public string RemoveAssemblyName(string asm) 
     {
-      return asm.Substring(0,asm.IndexOf(','));
+        int idx = asm.IndexOf(',');
+        if (idx == -1)
+            return asm;
+        return asm.Substring(0, idx);
     }
     public string RemoveNamespace(string asm) 
     {


### PR DESCRIPTION
Sometime when you add a txr file with some assemblies like "a.b.c.d.e" (without commas) the method RemoveAssemblyName in Trxer.xslt fails.

With this fix this application worked very well for me.